### PR TITLE
fix isFeatureEnabled function arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var featureToggles = {
         var toggle = this._toggles[featureName];
         if (typeof toggle == 'function') {
             try {
-                var toggleArguments = slice.call(arguments, 1);
+                var toggleArguments = Array.prototype.slice.call(arguments, 1);
                 toggle = toggle.apply(this, toggleArguments);
             }
             catch (error) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -150,6 +150,18 @@ describe('when checking if a feature is enabled', function() {
 
     });
 
+    describe('which has a function with arguments as value which returns true', function() {
+
+        beforeEach(function() {
+            featureToggles.load({foo: function(a) { var b = 'bar'; return a === b; }})
+        });
+
+        it('should return true', function() {
+            expect(featureToggles.isFeatureEnabled('foo', 'bar')).toBeTruthy();
+        });
+
+    });
+
 });
 
 describe('when checking multiple times if a feature is enabled which has a function as value', function() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Alex Lawrence",
   "license": "MIT",
   "devDependencies": {
-      "grunt": "0.4.1",
-      "jasmine-node": "1.7.0"
+      "grunt": "0.4.5",
+      "jasmine-node": "1.14.5"
   }
 }


### PR DESCRIPTION
I was unable to use functions in my feature list and I found this little bug.

"The arguments object is not an Array. It is similar to an Array, but
does not have any Array properties except length."
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
